### PR TITLE
Disclaim flags to fix module registration

### DIFF
--- a/fancyflags/__init__.py
+++ b/fancyflags/__init__.py
@@ -14,6 +14,7 @@
 # ============================================================================
 """An extended flags library. The main component is a nested dict flag."""
 
+from absl import flags
 from fancyflags import _auto
 from fancyflags import _define_auto
 from fancyflags import _definitions
@@ -21,6 +22,9 @@ from fancyflags import _metadata
 # internal imports: usage_logging
 
 __version__ = _metadata.__version__
+
+# Add current module to disclaimed module ids.
+flags.disclaim_key_flags()
 
 # pylint: disable=invalid-name
 

--- a/fancyflags/_define_auto.py
+++ b/fancyflags/_define_auto.py
@@ -23,6 +23,8 @@ from fancyflags import _flags
 
 _T = TypeVar('_T')
 
+# Add current module to disclaimed module ids.
+flags.disclaim_key_flags()
 
 def DEFINE_auto(  # pylint: disable=invalid-name
     name: str,

--- a/fancyflags/_define_auto_test.py
+++ b/fancyflags/_define_auto_test.py
@@ -108,5 +108,16 @@ class DefineAutoTest(absltest.TestCase):
     flag_values(['./program'] + serialized_args)
     self.assertEqual(flag_values['point'].value(), parsed_point_value)
 
+  def test_disclaimed_module(self):
+    flag_values = flags.FlagValues()
+    _ = _define_auto.DEFINE_auto(
+      'greet', greet, 'help string', flag_values=flag_values)
+    defining_module = flag_values.find_module_defining_flag('greet')
+
+    # the defining module should be the calling module, not the module where
+    # the flag is defined. otherwise the help for a module's flags will not be
+    # printed unless the user uses --helpfull.
+    self.assertEqual(defining_module, 'fancyflags._define_auto_test')
+
 if __name__ == '__main__':
   absltest.main()

--- a/fancyflags/_define_auto_test.py
+++ b/fancyflags/_define_auto_test.py
@@ -114,8 +114,8 @@ class DefineAutoTest(absltest.TestCase):
       'greet', greet, 'help string', flag_values=flag_values)
     defining_module = flag_values.find_module_defining_flag('greet')
 
-    # the defining module should be the calling module, not the module where
-    # the flag is defined. otherwise the help for a module's flags will not be
+    # The defining module should be the calling module, not the module where
+    # the flag is defined. Otherwise the help for a module's flags will not be
     # printed unless the user uses --helpfull.
     self.assertEqual(defining_module, 'fancyflags._define_auto_test')
 


### PR DESCRIPTION
Disclaim flags in modules containing flag definitions so that usage of
`DEFINE_auto` and `DEFINE_dict` register flags to the correct calling
modules. This affects functions that perform logic by a flags' registered
module, for example, help formatting. Without disclaiming the flags, help
for a module's flags won't be displayed unless the user uses --helpfull (in
which case all flags are listed under `fancyflags._define_auto`).